### PR TITLE
Add way to serialize and deserialize config settings to and from TOML

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@
 #![allow(dead_code)]
 
 mod locate;
+mod settings;
 mod toml;
 
 use env_logger::Builder as EnvLogBuilder;

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,8 +1,14 @@
 // SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
 // SPDX-License-Identifier: MIT
 
-use std::path::PathBuf;
-use toml_edit::{Key, Item};
+use std::{
+    fmt::{Display, Formatter, Result as FmtResult},
+    path::PathBuf,
+};
+use toml_edit::{
+    visit::{visit_table_like_kv, Visit},
+    Item, Key,
+};
 
 #[derive(Debug, Default, Eq, PartialEq, Clone)]
 pub struct RepoSettings {
@@ -23,8 +29,7 @@ impl RepoSettings {
             name: name.into(),
             branch: branch.into(),
             remote: remote.into(),
-            worktree: Default::default(),
-            bootstrap: Default::default(),
+            ..Default::default()
         }
     }
 
@@ -39,9 +44,34 @@ impl RepoSettings {
     }
 }
 
+fn from_toml<'toml>(entry: (&'toml Key, &'toml Item)) -> RepoSettings {
+    let (key, value) = entry;
+    let mut repo = RepoSettings { name: key.get().into(), ..Default::default() };
+    repo.visit_item(value);
+    repo
+}
+
 impl<'toml> From<(&'toml Key, &'toml Item)> for RepoSettings {
     fn from(entry: (&'toml Key, &'toml Item)) -> Self {
-        todo!();
+        from_toml(entry)
+    }
+}
+
+impl<'toml> Visit<'toml> for RepoSettings {
+    fn visit_table_like_kv(&mut self, key: &'toml str, node: &'toml Item) {
+        match key {
+            "branch" => self.branch = node.as_str().unwrap_or("master").into(),
+            "remote" => self.remote = node.as_str().unwrap_or("origin").into(),
+            "worktree" => self.worktree = node.as_str().map(|s| s.into()),
+            "bootstrap" => {
+                let mut bootstrap = BootstrapSettings::default();
+                bootstrap.visit_item(node);
+                self.bootstrap = Some(bootstrap);
+            }
+            &_ => visit_table_like_kv(self, key, node),
+        };
+
+        visit_table_like_kv(self, key, node);
     }
 }
 
@@ -57,14 +87,7 @@ pub struct BootstrapSettings {
 
 impl BootstrapSettings {
     pub fn new(url: impl Into<String>) -> Self {
-        Self {
-            clone: url.into(),
-            os: Default::default(),
-            depends: Default::default(),
-            ignores: Default::default(),
-            users: Default::default(),
-            hosts: Default::default(),
-        }
+        Self { clone: url.into(), ..Default::default() }
     }
 
     pub fn with_os(mut self, kind: OsKind) -> Self {
@@ -101,6 +124,38 @@ impl BootstrapSettings {
     }
 }
 
+impl<'toml> Visit<'toml> for BootstrapSettings {
+    fn visit_table_like_kv(&mut self, key: &'toml str, node: &'toml Item) {
+        match key {
+            "clone" => self.clone = node.as_str().unwrap_or_default().into(),
+            "os" => self.os = node.as_str().map(|k| OsKind::from(k)),
+            "depends" => {
+                self.depends = node.as_array().map(|a| {
+                    a.into_iter().map(|s| s.as_str().unwrap_or_default().to_string()).collect()
+                })
+            }
+            "ignores" => {
+                self.ignores = node.as_array().map(|a| {
+                    a.into_iter().map(|s| s.as_str().unwrap_or_default().to_string()).collect()
+                })
+            }
+            "users" => {
+                self.users = node.as_array().map(|a| {
+                    a.into_iter().map(|s| s.as_str().unwrap_or_default().to_string()).collect()
+                })
+            }
+            "hosts" => {
+                self.hosts = node.as_array().map(|a| {
+                    a.into_iter().map(|s| s.as_str().unwrap_or_default().to_string()).collect()
+                })
+            }
+            &_ => visit_table_like_kv(self, key, node),
+        };
+
+        visit_table_like_kv(self, key, node);
+    }
+}
+
 #[derive(Debug, Default, Eq, PartialEq, Clone)]
 pub enum OsKind {
     #[default]
@@ -113,15 +168,38 @@ pub enum OsKind {
     Windows,
 }
 
+impl From<&str> for OsKind {
+    fn from(data: &str) -> Self {
+        match data {
+            "any" => Self::Any,
+            "unix" => Self::Unix,
+            "macos" => Self::MacOs,
+            "windows" => Self::Windows,
+            &_ => Self::Any,
+        }
+    }
+}
+
+impl Display for OsKind {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match self {
+            OsKind::Any => write!(f, "any"),
+            OsKind::Unix => write!(f, "unix"),
+            OsKind::MacOs => write!(f, "macos"),
+            OsKind::Windows => write!(f, "windows"),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    use indoc::indoc;
     use pretty_assertions::assert_eq;
     use rstest::{fixture, rstest};
     use snafu::report;
     use toml_edit::{DocumentMut, TomlError};
-    use indoc::indoc;
 
     #[fixture]
     fn repo_settings_doc() -> Result<DocumentMut, TomlError> {
@@ -131,9 +209,13 @@ mod tests {
             remote = "origin"
             worktree = "$HOME"
 
+            [foo.should_ignore_this]
+            clone = "https://some/url"
+            os = "unix"
+
             [bar]
             branch = "main"
-            remote = "origin"
+            remote = "upstream"
             worktree = "$HOME"
 
             [bar.bootstrap]
@@ -155,7 +237,7 @@ mod tests {
             .with_worktree("$HOME")
     )]
     #[case::with_bootstrap(
-        RepoSettings::new("bar", "main", "origin")
+        RepoSettings::new("bar", "main", "upstream")
             .with_worktree("$HOME")
             .with_bootstrap(
                 BootstrapSettings::new("https://some/url")

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -191,6 +191,51 @@ impl Display for OsKind {
     }
 }
 
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct CmdHookSettings {
+    pub cmd: String,
+    pub hooks: Vec<HookSettings>,
+}
+
+impl CmdHookSettings {
+    pub fn new(cmd: impl Into<String>) -> Self {
+        Self { cmd: cmd.into(), ..Default::default() }
+    }
+
+    pub fn add_hook(mut self, hook: HookSettings) -> Self {
+        self.hooks.push(hook);
+        self
+    }
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct HookSettings {
+    pub pre: Option<String>,
+    pub post: Option<String>,
+    pub workdir: Option<PathBuf>,
+}
+
+impl HookSettings {
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    pub fn with_pre(mut self, script: impl Into<String>) -> Self {
+        self.pre = Some(script.into());
+        self
+    }
+
+    pub fn with_post(mut self, script: impl Into<String>) -> Self {
+        self.post = Some(script.into());
+        self
+    }
+
+    pub fn with_workdir(mut self, path: impl Into<PathBuf>) -> Self {
+        self.workdir = Some(path.into());
+        self
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -65,11 +65,13 @@ impl RepoSettings {
             }
 
             if let Some(depends) = &bootstrap.depends {
-                bootstrap_opts.insert("depends", Item::Value(Value::Array(Array::from_iter(depends))));
+                bootstrap_opts
+                    .insert("depends", Item::Value(Value::Array(Array::from_iter(depends))));
             }
 
             if let Some(ignores) = &bootstrap.ignores {
-                bootstrap_opts.insert("ignores", Item::Value(Value::Array(Array::from_iter(ignores))));
+                bootstrap_opts
+                    .insert("ignores", Item::Value(Value::Array(Array::from_iter(ignores))));
             }
 
             if let Some(users) = &bootstrap.users {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,0 +1,107 @@
+// SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
+// SPDX-License-Identifier: MIT
+
+use std::path::PathBuf;
+
+#[derive(Debug, Default, Eq, PartialEq, Clone)]
+pub struct RepoSettings {
+    pub name: String,
+    pub branch: String,
+    pub remote: String,
+    pub worktree: Option<PathBuf>,
+    pub bootstrap: Option<BootstrapSettings>,
+}
+
+impl RepoSettings {
+    pub fn new(
+        name: impl Into<String>,
+        branch: impl Into<String>,
+        remote: impl Into<String>,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            branch: branch.into(),
+            remote: remote.into(),
+            worktree: Default::default(),
+            bootstrap: Default::default(),
+        }
+    }
+
+    pub fn with_worktree(mut self, worktree: impl Into<PathBuf>) -> Self {
+        self.worktree = Some(worktree.into());
+        self
+    }
+
+    pub fn with_bootstrap(mut self, bootstrap: BootstrapSettings) -> Self {
+        self.bootstrap = Some(bootstrap);
+        self
+    }
+}
+
+#[derive(Debug, Default, Eq, PartialEq, Clone)]
+pub struct BootstrapSettings {
+    pub clone: String,
+    pub os: Option<OsKind>,
+    pub depends: Option<Vec<String>>,
+    pub ignores: Option<Vec<String>>,
+    pub users: Option<Vec<String>>,
+    pub hosts: Option<Vec<String>>,
+}
+
+impl BootstrapSettings {
+    pub fn new(url: impl Into<String>) -> Self {
+        Self {
+            clone: url.into(),
+            os: Default::default(),
+            depends: Default::default(),
+            ignores: Default::default(),
+            users: Default::default(),
+            hosts: Default::default(),
+        }
+    }
+
+    pub fn with_os(mut self, kind: OsKind) -> Self {
+        self.os = Some(kind);
+        self
+    }
+
+    pub fn with_depends(mut self, depends: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        let mut vec = Vec::new();
+        vec.extend(depends.into_iter().map(Into::into));
+        self.depends = Some(vec);
+        self
+    }
+
+    pub fn with_ignores(mut self, ignores: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        let mut vec = Vec::new();
+        vec.extend(ignores.into_iter().map(Into::into));
+        self.ignores = Some(vec);
+        self
+    }
+
+    pub fn with_users(mut self, users: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        let mut vec = Vec::new();
+        vec.extend(users.into_iter().map(Into::into));
+        self.users = Some(vec);
+        self
+    }
+
+    pub fn with_hosts(mut self, hosts: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        let mut vec = Vec::new();
+        vec.extend(hosts.into_iter().map(Into::into));
+        self.hosts = Some(vec);
+        self
+    }
+}
+
+#[derive(Debug, Default, Eq, PartialEq, Clone)]
+pub enum OsKind {
+    #[default]
+    Any,
+
+    Unix,
+
+    MacOs,
+
+    Windows,
+}

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -181,7 +181,7 @@ impl<'toml> Visit<'toml> for BootstrapSettings {
     fn visit_table_like_kv(&mut self, key: &'toml str, node: &'toml Item) {
         match key {
             "clone" => self.clone = node.as_str().unwrap_or_default().into(),
-            "os" => self.os = node.as_str().map(|k| OsKind::from(k)),
+            "os" => self.os = node.as_str().map(OsKind::from),
             "depends" => {
                 self.depends = node.as_array().map(|a| {
                     a.into_iter().map(|s| s.as_str().unwrap_or_default().to_string()).collect()


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
SPDX-License-Identifier: MIT
-->

## Description

This pull request implements a way to serialize and deserialize config settings from TOML data in the `settings` module for both repository and command hook configurations.

## Area of Effect

- Module `settings`.
