### PR TITLE
Implement Git VCS API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,7 +113,7 @@ dependencies = [
 
 [[package]]
 name = "dotfile-ocd"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "directories",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 authors = ["Jason Pena <jasonpena@awkless.com>"]
 edition = "2021"
 license = "MIT"
-version = "0.2.0"
+version = "0.3.0"
 rust-version = "1.77.2"
 
 [[bin]]
@@ -25,10 +25,10 @@ indoc = "~2.0.5"
 log = "~0.4.22"
 mkdirp = "~1.0.0"
 snafu = "~0.8.5"
-tempfile = "~3.14.0"
 toml_edit = "~0.22.22"
 
 [dev-dependencies]
 mockall = "~0.13.0"
 pretty_assertions = "~1.4.1"
 rstest = "~0.23.0"
+tempfile = "~3.14.0"

--- a/src/vcs.rs
+++ b/src/vcs.rs
@@ -89,4 +89,12 @@ mod tests {
 
         Ok(())
     }
+
+    #[rstest]
+    fn git_run_return_err() {
+        let mut git = Git::new();
+        git.with_args(["unknown-cmd", "--fail"]);
+        let result = git.run();
+        assert!(matches!(result.unwrap_err().0, InnerGitError::GitBin { .. }));
+    }
 }

--- a/src/vcs.rs
+++ b/src/vcs.rs
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
+// SPDX-License-Identifier: MIT
+
+use std::ffi::OsString;
+use snafu::prelude::*;
+
+#[derive(Debug, Default, Clone)]
+pub struct Git {
+    args: Vec<OsString>,
+}
+
+impl Git {
+    pub fn new() -> Self {
+        todo!();
+    }
+
+    pub fn with_args(mut self, args: impl IntoIterator<Item = impl Into<OsString>>) -> Self {
+        todo!();
+    }
+
+    pub fn run(&self) -> Result<(), GitError> {
+        todo!();
+    }
+}
+
+/// Git error type public API.
+#[derive(Debug, Snafu)]
+pub struct GitError(InnerGitError);
+
+/// Alias to allow one-off functions with different error type.
+pub type Result<T, E = GitError> = std::result::Result<T, E>;
+
+#[derive(Debug, Snafu)]
+enum InnerGitError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+}

--- a/src/vcs.rs
+++ b/src/vcs.rs
@@ -18,7 +18,7 @@ impl Git {
         todo!();
     }
 
-    pub fn run(&self) -> Result<(), GitError> {
+    pub fn run(&self) -> Result<String, GitError> {
         todo!();
     }
 }
@@ -36,4 +36,19 @@ enum InnerGitError {}
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    use rstest::rstest;
+    use snafu::{report, Whatever};
+    use pretty_assertions::assert_eq;
+
+    #[rstest]
+    #[report]
+    fn git_run_return_str() -> Result<(), Whatever> {
+        let result = Git::new().with_args(["ls-files", "--", "README.md"]).run()
+            .with_whatever_context(|_| "Failed to run Git binary")?;
+        let expect = "README.md".to_string();
+        assert_eq!(result, expect);
+
+        Ok(())
+    }
 }

--- a/src/vcs.rs
+++ b/src/vcs.rs
@@ -1,25 +1,56 @@
 // SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
 // SPDX-License-Identifier: MIT
 
-use std::ffi::OsString;
+use std::{
+    ffi::OsString,
+    process::Command,
+    io::Error as IoError,
+};
 use snafu::prelude::*;
+use log::info;
 
+/// Git binary handler.
+///
+/// Manages system calls to user's Git binary to help manage Git repository
+/// data.
 #[derive(Debug, Default, Clone)]
 pub struct Git {
     args: Vec<OsString>,
 }
 
 impl Git {
+    /// Construct new Git handler.
     pub fn new() -> Self {
-        todo!();
+        Default::default()
     }
 
-    pub fn with_args(mut self, args: impl IntoIterator<Item = impl Into<OsString>>) -> Self {
-        todo!();
+    /// Add arguments to pass to Git binary.
+    pub fn with_args(&mut self, args: impl IntoIterator<Item = impl Into<OsString>>) {
+        self.args.extend(args.into_iter().map(Into::into));
     }
 
-    pub fn run(&self) -> Result<String, GitError> {
-        todo!();
+    /// Call Git binary.
+    ///
+    /// Will pass given arguments to Git binary. Will log and return any output
+    /// Git has written to stdout after calling it. Any arguments given will
+    /// also be cleared for new arguments to be passed later on.
+    ///
+    /// # Errors
+    ///
+    /// Will fail if system call to Git binary fails, or Git binary itself fails
+    /// to execute with given arguments.
+    pub fn run(&mut self) -> Result<String, GitError> {
+        let output = Command::new("git").args(&self.args).output().context(SyscallSnafu)?;
+        if !output.status.success() {
+            let msg = String::from_utf8_lossy(output.stderr.as_slice()).into_owned();
+            return Err(GitError(InnerGitError::GitBin { msg }));
+        }
+
+        let msg = String::from_utf8_lossy(output.stdout.as_slice()).into_owned();
+        info!("{msg}");
+        self.args.clear();
+
+        Ok(msg)
     }
 }
 
@@ -31,7 +62,13 @@ pub struct GitError(InnerGitError);
 pub type Result<T, E = GitError> = std::result::Result<T, E>;
 
 #[derive(Debug, Snafu)]
-enum InnerGitError {}
+enum InnerGitError {
+    #[snafu(display("Failed to make syscall to Git binary"))]
+    Syscall { source: IoError },
+
+    #[snafu(display("{msg}"))]
+    GitBin { msg: String },
+}
 
 #[cfg(test)]
 mod tests {
@@ -44,9 +81,10 @@ mod tests {
     #[rstest]
     #[report]
     fn git_run_return_str() -> Result<(), Whatever> {
-        let result = Git::new().with_args(["ls-files", "--", "README.md"]).run()
-            .with_whatever_context(|_| "Failed to run Git binary")?;
-        let expect = "README.md".to_string();
+        let mut git = Git::new();
+        git.with_args(["ls-files", "--", "README.md"]);
+        let result = git.run().with_whatever_context(|_| "Failed to run Git binary")?;
+        let expect = "README.md\n".to_string();
         assert_eq!(result, expect);
 
         Ok(())


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
SPDX-License-Identifier: MIT
-->

## Description

Implementation of Git VCS handler API that makes syscalls to Git binary, which will be eventually used for repository management logic in the future.

## Area of Effect

- Module `vcs`.

## Tasks

- [x] Implement `crate::vcs::Git::new`
- [x] Implement `crate::vcs::Git::with_args`
- [x] Implement `crate::vcs::Git::run`
