### PR TITLE
Ensure that user does not have duplicate entries for array fields in bootstrap settings

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -326,7 +326,7 @@ mod tests {
                         [repos.vim]
                         branch = "master"
                         remote = "origin"
-                        worktree = "$HOME"
+                        bare_alias = "$HOME"
 
                         [hooks]
                         bootstrap = [
@@ -417,7 +417,7 @@ mod tests {
     #[rstest]
     #[case::repo_config(
         RepoConfig,
-        RepoSettings::new("dwm", "main", "upstream").with_worktree("$HOME")
+        RepoSettings::new("dwm", "main", "upstream").with_bare_alias("$HOME")
     )]
     #[case::cmd_hook_config(
         CmdHookConfig,
@@ -474,7 +474,7 @@ mod tests {
     #[case::repo_config(
         RepoConfig,
         "vim",
-        RepoSettings::new("vim", "master", "origin").with_worktree("$HOME")
+        RepoSettings::new("vim", "master", "origin").with_bare_alias("$HOME")
     )]
     #[case::repo_config(
         CmdHookConfig,
@@ -538,7 +538,7 @@ mod tests {
     #[rstest]
     #[case::repo_config(
         RepoConfig,
-        RepoSettings::new("dwm", "main", "upstream").with_worktree("$HOME")
+        RepoSettings::new("dwm", "main", "upstream").with_bare_alias("$HOME")
     )]
     #[case::cmd_hook_config(
         CmdHookConfig,
@@ -574,8 +574,8 @@ mod tests {
     #[rstest]
     #[case::repo_config(
         RepoConfig,
-        RepoSettings::new("vim", "main", "upstream").with_worktree("$HOME"),
-        Some(RepoSettings::new("vim", "master", "origin").with_worktree("$HOME")),
+        RepoSettings::new("vim", "main", "upstream").with_bare_alias("$HOME"),
+        Some(RepoSettings::new("vim", "master", "origin").with_bare_alias("$HOME")),
     )]
     #[case::cmd_hook_config(
         CmdHookConfig,
@@ -644,7 +644,7 @@ mod tests {
     #[case::repo_config(
         RepoConfig,
         "vim",
-        RepoSettings::new("vim", "master", "origin").with_worktree("$HOME"),
+        RepoSettings::new("vim", "master", "origin").with_bare_alias("$HOME"),
     )]
     #[case::cmd_hook_config(
         CmdHookConfig,

--- a/src/config/toml.rs
+++ b/src/config/toml.rs
@@ -65,7 +65,7 @@ impl Toml {
 
         let entry = match self.get_table_mut(table.as_ref()) {
             Ok(table) => table,
-            Err(InnerTomlError::TableNotFound { .. }) => {
+            Err(TomlError(InnerTomlError::TableNotFound { .. })) => {
                 let mut new_table = Table::new();
                 new_table.set_implicit(true);
                 self.doc.insert(table.as_ref(), Item::Table(new_table));
@@ -100,14 +100,14 @@ impl Toml {
         Ok(entry)
     }
 
-    fn get_table(&self, key: &str) -> Result<&Table, InnerTomlError> {
+    pub fn get_table(&self, key: &str) -> Result<&Table, TomlError> {
         let table = self.doc.get(key).context(TableNotFoundSnafu { table: key })?;
         let table = table.as_table().context(NotTableSnafu { table: key })?;
 
         Ok(table)
     }
 
-    fn get_table_mut(&mut self, key: &str) -> Result<&mut Table, InnerTomlError> {
+    pub fn get_table_mut(&mut self, key: &str) -> Result<&mut Table, TomlError> {
         let table = self.doc.get_mut(key).context(TableNotFoundSnafu { table: key })?;
         let table = table.as_table_mut().context(NotTableSnafu { table: key })?;
 

--- a/src/config/toml.rs
+++ b/src/config/toml.rs
@@ -71,7 +71,7 @@ impl Toml {
                 self.doc.insert(table.as_ref(), Item::Table(new_table));
                 self.doc[table.as_ref()].as_table_mut().unwrap()
             }
-            Err(err) => return Err(err.into()),
+            Err(err) => return Err(err),
         };
         let entry = entry.insert(key.get(), value).map(|old| (key, old));
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@
 
 mod config;
 mod vcs;
+mod repo;
 
 #[cfg(test)]
 mod testenv;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,8 +4,8 @@
 #![allow(dead_code)]
 
 mod config;
-mod vcs;
 mod repo;
+mod vcs;
 
 #[cfg(test)]
 mod testenv;

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
+// SPDX-License-Identifier: MIT
+
+use crate::{
+    config::{ConfigFile, RepoConfig, Locator},
+    vcs::Git,
+};
+
+/// Manage repository collection.
+pub struct RepoManager<'repo, L>
+where
+    L: Locator,
+{
+    git: Git,
+    config: ConfigFile<'repo, RepoConfig, L>,
+    locator: &'repo L,
+}
+
+impl<'repo, L> RepoManager<'repo, L>
+where
+    L: Locator,
+{
+    /// Construct new repository manager.
+    pub fn new(config: ConfigFile<'repo, RepoConfig, L>, locator: &'repo L) -> Self {
+        Self { git: Git::new(), config, locator }
+    }
+}

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -2,11 +2,15 @@
 // SPDX-License-Identifier: MIT
 
 use crate::{
-    config::{ConfigFile, RepoConfig, Locator},
+    config::{ConfigError, ConfigFile, Locator, RepoConfig, RepoSettings},
     vcs::Git,
 };
 
+use snafu::prelude::*;
+use std::collections::HashMap;
+
 /// Manage repository collection.
+#[derive(Debug)]
 pub struct RepoManager<'repo, L>
 where
     L: Locator,
@@ -21,7 +25,189 @@ where
     L: Locator,
 {
     /// Construct new repository manager.
-    pub fn new(config: ConfigFile<'repo, RepoConfig, L>, locator: &'repo L) -> Self {
-        Self { git: Git::new(), config, locator }
+    pub fn manage(
+        config: ConfigFile<'repo, RepoConfig, L>,
+        locator: &'repo L,
+    ) -> Result<Self, RepoManagerError> {
+        let repo_mgr = Self { git: Git::new(), config, locator };
+        repo_mgr.check_duplicate_setting_array_values()?;
+
+        Ok(repo_mgr)
+    }
+
+    fn check_duplicate_setting_array_values(&self) -> Result<(), InnerRepoManagerError> {
+        let repos: Vec<RepoSettings> = self.config.iter().collect();
+        for repo in repos {
+            if let Some(bootstrap) = repo.bootstrap {
+                let result = find_duplicates(&bootstrap.depends.unwrap_or_default());
+                if !result.is_empty() {
+                    return Err(InnerRepoManagerError::DuplicateSettingValues {
+                        setting: format!("{}.bootstrap.depends", repo.name),
+                        duplicates: result,
+                    });
+                }
+
+                let result = find_duplicates(&bootstrap.ignores.unwrap_or_default());
+                if !result.is_empty() {
+                    return Err(InnerRepoManagerError::DuplicateSettingValues {
+                        setting: format!("{}.bootstrap.ignores", repo.name),
+                        duplicates: result,
+                    });
+                }
+
+                let result = find_duplicates(&bootstrap.users.unwrap_or_default());
+                if !result.is_empty() {
+                    return Err(InnerRepoManagerError::DuplicateSettingValues {
+                        setting: format!("{}.bootstrap.users", repo.name),
+                        duplicates: result,
+                    });
+                }
+
+                let result = find_duplicates(&bootstrap.hosts.unwrap_or_default());
+                if !result.is_empty() {
+                    return Err(InnerRepoManagerError::DuplicateSettingValues {
+                        setting: format!("{}.bootstrap.hosts", repo.name),
+                        duplicates: result,
+                    });
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+fn find_duplicates(entries: &Vec<String>) -> Vec<String> {
+    let mut values: HashMap<String, usize> = HashMap::new();
+    let mut duplicates = Vec::new();
+    for entry in entries {
+        match values.get_key_value(entry) {
+            Some((key, value)) => {
+                if *value >= 1 {
+                    duplicates.push(entry.clone());
+                } else {
+                    values.insert(key.clone(), value + 1);
+                }
+            }
+            None => _ = values.insert(entry.clone(), 1),
+        };
+    }
+
+    duplicates
+}
+
+#[derive(Debug, Snafu)]
+pub struct RepoManagerError(InnerRepoManagerError);
+
+pub type Result<T, E = RepoManagerError> = std::result::Result<T, E>;
+
+#[derive(Debug, Snafu)]
+enum InnerRepoManagerError {
+    ConfigFile {
+        source: ConfigError,
+    },
+
+    #[snafu(display("Repository setting '{setting}' contains duplicate entries: '{:}'"))]
+    DuplicateSettingValues {
+        setting: String,
+        duplicates: Vec<String>,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::{
+        config::MockLocator,
+        testenv::{FileKind, FixtureHarness},
+    };
+
+    use indoc::indoc;
+    use rstest::{fixture, rstest};
+    use snafu::{report, Whatever};
+
+    #[fixture]
+    fn config_dir() -> Result<FixtureHarness, Whatever> {
+        let harness = FixtureHarness::open()?
+            .with_file("repos.toml", |fixture| {
+                fixture
+                    .data(indoc! {r#"
+                        [repos.vim]
+                        branch = "master"
+                        remote = "origin"
+                        bare_alias = "$HOME"
+
+                        [repos.vim.bootstrap]
+                        clone = "https://some/url"
+                        os = "unix"
+                        depends = ["foo", "baz"]
+                        ignores = ["LICENSE*", "README*"]
+                        users = ["awkless", "lovelace"]
+                        hosts = ["lovelace", "turing"]
+                    "#})
+                    .kind(FileKind::Normal)
+                    .write()
+            })?
+            .with_file("duplicates.toml", |fixture| {
+                fixture
+                    .data(indoc! {r#"
+                        [repos.vim]
+                        branch = "master"
+                        remote = "origin"
+                        bare_alias = "$HOME"
+
+                        [repos.vim.bootstrap]
+                        clone = "https://some/url"
+                        os = "unix"
+                        depends = ["foo", "baz"]
+                        ignores = ["LICENSE*", "README*"]
+                        users = ["awkless", "awkless"]
+                        hosts = ["lovelace", "turing"]
+                    "#})
+                    .kind(FileKind::Normal)
+                    .write()
+            })?;
+
+        Ok(harness)
+    }
+
+    #[report]
+    #[rstest]
+    fn repo_manager_manage_check_duplicate_settings_return_self(
+        config_dir: Result<FixtureHarness, Whatever>,
+    ) -> Result<(), Whatever> {
+        let config_dir = config_dir?;
+        let fixture = config_dir.get("repos.toml")?;
+        let mut locator = MockLocator::new();
+        locator.expect_repo_config_file().return_const(fixture.as_path().into());
+        let config = ConfigFile::load(RepoConfig, &locator)
+            .with_whatever_context(|_| "Failed to load configuration file")?;
+
+        let result = RepoManager::manage(config, &locator);
+        assert!(result.is_ok());
+
+        Ok(())
+    }
+
+    #[report]
+    #[rstest]
+    fn repo_manager_manage_check_duplicate_settings_return_err(
+        config_dir: Result<FixtureHarness, Whatever>,
+    ) -> Result<(), Whatever> {
+        let config_dir = config_dir?;
+        let fixture = config_dir.get("duplicates.toml")?;
+        let mut locator = MockLocator::new();
+        locator.expect_repo_config_file().return_const(fixture.as_path().into());
+        let config = ConfigFile::load(RepoConfig, &locator)
+            .with_whatever_context(|_| "Failed to load configuration file")?;
+
+        let result = RepoManager::manage(config, &locator);
+        assert!(matches!(
+            result.unwrap_err().0,
+            InnerRepoManagerError::DuplicateSettingValues { .. }
+        ));
+
+        Ok(())
     }
 }

--- a/src/vcs.rs
+++ b/src/vcs.rs
@@ -20,6 +20,11 @@ impl Git {
         Default::default()
     }
 
+    /// Add single argument to pass to Git binary.
+    pub fn with_arg(&mut self, arg: impl Into<OsString>) {
+        self.args.push(arg.into());
+    }
+
     /// Add arguments to pass to Git binary.
     pub fn with_args(&mut self, args: impl IntoIterator<Item = impl Into<OsString>>) {
         self.args.extend(args.into_iter().map(Into::into));


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
SPDX-License-Identifier: MIT
-->

## Description

This pull request sets up the `repo` module in order to begin implementing the `RepoManager` type. The `RepoManger` object will manage repository data that the user has defined and setup within the configuration file and repository directory. Currently, I have begun to make the constructor `RepoManager::manage` perform a series of semantic checks regarding configuration information.
Currently, this pull request ensures that the user does not have duplicate entries in any array fields for bootstrap settings per repository configuration.

## Area of Effect

- Module `config`.
- Module `repo`.
