### PR TITLE
Implement `init` command through `RepoManager::init`

### DIFF
--- a/src/repo.rs
+++ b/src/repo.rs
@@ -11,7 +11,7 @@ pub use vcs::*;
 use crate::config::{ConfigError, ConfigFile, Locator, RepoConfig, RepoSettings};
 
 use snafu::prelude::*;
-use std::collections::HashSet;
+use std::{collections::HashSet, path::PathBuf};
 
 /// Manage repository collection.
 #[derive(Debug)]
@@ -46,6 +46,39 @@ where
         deps.acyclic_check().context(DependencySnafu)?;
 
         Ok(Self { git: Git::new(), config, locator, deps })
+    }
+
+    /// Initialize new repository.
+    ///
+    /// Initialize repository through Git, and add an entry for it in special
+    /// configuration file.
+    ///
+    /// # Errors
+    ///
+    /// Will fail if new repository cannot be initialized, or added into
+    /// configuration file.
+    pub fn init(
+        &mut self,
+        name: String,
+        branch: Option<String>,
+        bare_alias: Option<PathBuf>,
+    ) -> Result<(), RepoManagerError> {
+        let branch = if let Some(branch) = branch { branch.to_string() } else { "master".into() };
+        self.git.with_arg("init");
+
+        let mut repo = RepoSettings::new(&name, &branch, "origin");
+        if let Some(alias) = bare_alias {
+            repo = repo.with_bare_alias(alias.to_path_buf());
+            self.git.with_arg("--bare");
+        }
+
+        let dir_path = self.locator.repos_dir().join(&name).to_string_lossy().into_owned();
+        self.git.with_args(["--initial-branc", &branch, &dir_path]);
+        self.git.run().context(GitSnafu)?;
+        self.config.add(repo).context(ConfigFileSnafu)?;
+        self.config.save().context(ConfigFileSnafu)?;
+
+        Ok(())
     }
 }
 
@@ -97,19 +130,17 @@ pub type Result<T, E = RepoManagerError> = std::result::Result<T, E>;
 
 #[derive(Debug, Snafu)]
 enum InnerRepoManagerError {
-    ConfigFile {
-        source: ConfigError,
-    },
+    #[snafu(display("Configuration file management failure"))]
+    ConfigFile { source: ConfigError },
 
-    Dependency {
-        source: DependencyError,
-    },
+    #[snafu(display("Dependency management failure"))]
+    Dependency { source: DependencyError },
+
+    #[snafu(display("Git system call failure"))]
+    Git { source: GitError },
 
     #[snafu(display("Repository setting '{setting}' contains duplicate entries: '{:?}'"))]
-    DuplicateSettingValues {
-        setting: String,
-        duplicates: Vec<String>,
-    },
+    DuplicateSettingValues { setting: String, duplicates: Vec<String> },
 }
 
 #[cfg(test)]
@@ -122,6 +153,7 @@ mod tests {
     };
 
     use indoc::indoc;
+    use pretty_assertions::assert_eq;
     use rstest::{fixture, rstest};
     use snafu::{report, Whatever};
 
@@ -205,6 +237,38 @@ mod tests {
             result.unwrap_err().0,
             InnerRepoManagerError::DuplicateSettingValues { .. }
         ));
+
+        Ok(())
+    }
+
+    #[report]
+    #[rstest]
+    #[case::use_defaults("foo".to_string(), None, None)]
+    #[case::set_branch("bar".to_string(), Some("main".to_string()), None)]
+    #[case::set_bare_alias("baz".to_string(), Some("patch".to_string()), Some("/some/path".into()))]
+    fn repo_manager_init_add_repo_to_config_and_repo_dir(
+        config_dir: Result<FixtureHarness, Whatever>,
+        #[case] repo_name: String,
+        #[case] branch: Option<String>,
+        #[case] bare_alias: Option<PathBuf>,
+    ) -> Result<(), Whatever> {
+        let mut config_dir = config_dir?;
+        let repos_dir = config_dir.as_path().join("repos");
+        let fixture = config_dir.get_mut("repos.toml")?;
+        let mut locator = MockLocator::new();
+        locator.expect_repo_config_file().return_const(fixture.as_path().into());
+        locator.expect_repos_dir().return_const(repos_dir.clone());
+        let config = ConfigFile::load(RepoConfig, &locator)
+            .with_whatever_context(|_| "Failed to load configuration file")?;
+
+        let mut repo_mgr = RepoManager::manage(config, &locator)
+            .with_whatever_context(|_| "Failed to construct repository manager")?;
+        repo_mgr
+            .init(repo_name.clone(), branch, bare_alias)
+            .with_whatever_context(|_| "Failed to initialize new repository")?;
+        fixture.sync()?;
+        assert!(repos_dir.join(repo_name).exists());
+        assert_eq!(repo_mgr.config.to_string(), fixture.as_str());
 
         Ok(())
     }


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
SPDX-License-Identifier: MIT
-->

## Description

Implement the `init` command for the `ocd` binary through the implementation of `RepoManager::init` method.

## Area of Effect

- Binary.
- Module `repo`.
